### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,43 +3,17 @@
 [![CI Tests](https://github.com/sgibson91/test-this-pr-action/actions/workflows/ci.yml/badge.svg)](https://github.com/sgibson91/test-this-pr-action/actions/workflows/ci.yml)
 
 The fork --> develop --> open pull request workflow is a popular one across large software projects.
-However, if you have tests that require secrets, such as deploying to staging environments before production, this workflow can be a hindrance when managing that workflow through GitHub Actions, since the runner doesn't automatically grant access to repository secrets.
+However if you have tests that require secrets, such as deploying to staging environments before production, this workflow can be a hindrance when managing that workflow through GitHub Actions, since the runner doesn't automatically grant access to repository secrets.
 
-This repository is a Docker-based GitHub Action that will move a pull request opened from a fork into the parent repo so test workflows that require secrets can be executed.
-
-Yes, we could use [`ok-to-test`](https://github.com/imjohnbo/ok-to-test) instead.
-We found a lot of extra infrastructure was required to setup this action (e.g. a GitHub App) and we also wanted to take advantage of existing infrastructure that runs our staging deployment when a specific label is applied to an open pull request.
+This repository is a Docker-based GitHub Action that will push the changes of a pull request opened from a fork into a new branch in the parent repo so test workflows that require secrets can be executed.
 
 ## Inputs
 
-### `repository`
-
-This is the name of the parent repository in the form `owner/project`.
-It can be accessed during a workflow run with the `${{ github.repository }}` context.
-
-### `fork-owner`
-
-This is the account that holds the fork of the parent repository.
-It can be accessed during a workflow run _triggered by a pull request event_ in the `${{ github.event.pull_request.head.repo.owner.login }}` context.
-### `pr-number`
-
-This is the number of the pull request that was opened from a fork.
-It can be accessed during a workflow run _triggered by a pull request event_ in the `${{ github.event.number }}` context.
-
-### `pr-branch-name`
-
-This is the name of the branch in the fork from which the pull request originated.
-It can be accessed during a workflow run _triggered by a pull request event_ using the `${{ github.head_ref }}` context.
-
-### `github-token`
-
-This is a GitHub token with read/write access to the parent repository.
-During a workflow run `${{ secrets.GITHUB_TOKEN }}` should have the required permissions.
-
-### `apply-labels`
-
-This is an **optional** field that will apply labels to the new pull request, so long as those labels already exist in the repository.
-This field accepts a _whitespace separated_ list of inputs, hence it will **fail if your label names also include whitespace**.
+| Input variable | Description | Required? | Default value |
+| :--- | :--- | :--- | :--- |
+| `repository` | The name of the parent repository in the form `owner/project` | No | `${{ github.repository }}` |
+| `github-issue-context` | The context of the issue the trigger comment was left on (equivalent to a Pull Request to GitHub's API). From this context we can establish who owns the fork the PR originates from and the branch name. | No | `${{ github.event.issue }}` |
+| `github-token` | A GitHub token with read/write access to the parent repository | No | `${{ github.token }}` |
 
 ## Example Usage
 
@@ -48,7 +22,9 @@ The below example demonstrates how to trigger the GitHub Action by leaving a com
 ```yaml
 name: Move forked-PR into parent repo for testing
 
-on: [issue_comment]
+on:
+  issue_comment:
+    types: [created]
 
 jobs:
   test-this-pr:
@@ -67,12 +43,5 @@ jobs:
       )
 
     steps:
-      - uses: sgibson91/test-this-pr-action@master
-        with:
-          repository: ${{ github.repository }}
-          fork-owner: ${{ github.event.pull_request.head.repo.owner.login }}
-          pr-number: ${{ github.event.number }}
-          pr-branch-name: ${{ github.head_ref }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          apply-labels: test-staging label-1 label-2 ...
+      - uses: sgibson91/test-this-pr-action@main
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,36 +1,26 @@
 name: "Test this PR"
 author: "Sarah Gibson"
 description: |
-  Move a PR from a forked repo into the parent repo so that workflows that
-  require secrets can be run
+  Copy a PR from a forked repo into a branch on the parent repo so that
+  workflows that require secrets can be run
 inputs:
   repository:
     description: "The repository id in the form 'owner/project'"
-    required: true
-  fork-owner:
-    description: "The account that forked the parent repo"
-    required: true
-  pr-number:
-    description: "The number of the Pull Request to move into the parent repo"
-    required: true
-  pr-branch-name:
-    description: "The name of the source branch for the forked Pull Request"
-    required: true
+    required: false
+    default: github.repository
+  github-issue-context:
+    description: "The workflow context from the issue that triggered the run"
+    required: false
+    default: github.event.issue
   github-token:
     description: |
       A GitHub token with enough permissions to write to the parent repo
-    required: true
-  apply-labels:
-    description: |
-      A whitespace separated list of labels to apply to the new Pull Request
     required: false
+    default: github.token
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
     - ${{ inputs.repository }}
-    - ${{ inputs.fork-owner }}
-    - ${{ inputs.pr-number }}
-    - ${{ inputs.pr-branch-name }}
+    - ${{ inputs.github-issue-context }}
     - ${{ inputs.github-token }}
-    - ${{ inputs.apply-labels }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 black
 flake8
 pytest
-responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+ghapi

--- a/src/main.py
+++ b/src/main.py
@@ -1,32 +1,24 @@
 import os
-from utils import post_request, run_cmd
+import json
+from utils import run_cmd
+from ghapi.all import GhApi
+from ghapi.actions import github_token
 
 # Set required environment variables
 REPOSITORY = (
     os.environ["INPUT_REPOSITORY"] if "INPUT_REPOSITORY" in os.environ else None
 )
-FORK_OWNER = (
-    os.environ["INPUT_FORK_OWNER"] if "INPUT_FORK_OWNER" in os.environ else None
-)
-PR_NUMBER = os.environ["INPUT_PR_NUMBER"] if "INPUT_PR_NUMBER" in os.environ else None
-PR_BRANCH_NAME = (
-    os.environ["INPUT_PR_BRANCH_NAME"] if "InPUT_PR_BRANCH_NAME" in os.environ else None
+GITHUB_ISSUE_CONTEXT = (
+    json.loads(os.environ["INPUT_GITHUB-ISSUE-CONTEXT"]) if "INPUT_GITHUB-ISSUE-CONTEXT" in os.environ else None
 )
 GITHUB_TOKEN = (
-    os.environ["INPUT_GITHUB_TOKEN"] if "INPUT_GITHUB_TOKEN" in os.environ else None
-)
-
-# Set optional environment variables
-APPLY_LABELS = (
-    os.environ["INPUT_APPLY_LABELS"] if "INPUT_APPLY_LABELS" in os.environ else None
+    github_token() if "INPUT_GITHUB-TOKEN" not in os.environ else os.environ["INPUT_GITHUB-TOKEN"]
 )
 
 # Check required environment variables are set
 REQUIRED_ENV_VARS = {
     "REPOSITORY": REPOSITORY,
-    "FORK_OWNER": FORK_OWNER,
-    "PR_NUMBER": PR_NUMBER,
-    "PR_BRANCH_NAME": PR_BRANCH_NAME,
+    "GITHUB_ISSUE_CONTEXT": GITHUB_ISSUE_CONTEXT,
     "GITHUB_TOKEN": GITHUB_TOKEN,
 }
 
@@ -34,7 +26,23 @@ for VARNAME, VAR in REQUIRED_ENV_VARS.items():
     if VAR is None:
         raise ValueError(f"{VARNAME} must be set")
 
-PROJECT_NAME = REPOSITORY.split("/")[-1]
+# Initialise GhApi
+api = GhApi(token=GITHUB_TOKEN)
+
+# Set repository name
+REPO_NAME = REPOSITORY.split("/")[-1]
+
+# Set Pull Request number
+PR_NUMBER = GITHUB_ISSUE_CONTEXT["number"]
+
+# Get Pull Request info
+pr_info = api.pulls.get(REPOSITORY.split("/")[0], REPOSITORY.split("/")[-1], PR_NUMBER)
+
+# Set fork owner
+FORK_OWNER = pr_info.head.user.login
+
+# Set Pull Request branch name
+PR_BRANCH_NAME = pr_info.head.ref
 
 # Clone the parent repo
 _ = run_cmd(
@@ -46,7 +54,7 @@ _ = run_cmd(
 )
 
 # Change working directory
-os.chdir(PROJECT_NAME)
+os.chdir(REPO_NAME)
 
 # Add fork as remote
 _ = run_cmd(
@@ -55,7 +63,7 @@ _ = run_cmd(
         "remote",
         "add",
         "fork",
-        f"https://github.com/{FORK_OWNER}/{PROJECT_NAME}.git",
+        f"https://github.com/{FORK_OWNER}/{REPO_NAME}.git",
     ]
 )
 
@@ -97,47 +105,5 @@ _ = run_cmd(
     ]
 )
 
-# Get the default branch of the parent repo
-# to set as base branch of Pull Request
-result = run_cmd(
-    [
-        "git",
-        "symbolic-ref",
-        "refs/remotes/origin/HEAD",
-    ]
-)
-base_branch = result["output"].split("/")[-1]
-
-# Create Pull Request template
-pr = {
-    "title": f"Testing PR #{PR_NUMBER}",
-    "body": f"This PR is a copy of PR #{PR_NUMBER} which came from a fork. Tests that require secrets can now be run on this PR.",
-    "base": base_branch,
-    "head": f"test-this-pr/{PR_NUMBER}",
-}
-
-# Create the Pull Request
-resp = post_request(
-    f"https://api.github.com/repos/{REPOSITORY}/pulls",
-    headers={"Authorization": f"token {GITHUB_TOKEN}"},
-    json=pr,
-    return_json=True,
-)
-
-PR_URL = resp["html_url"]
-PR_URL_API = resp["issue_url"]
-
-# Add labels to the new PR
-if APPLY_LABELS is not None:
-    post_request(
-        PR_URL_API + "/labels",
-        headers={"Authorization": f"token {GITHUB_TOKEN}"},
-        json={"labels": APPLY_LABELS.split(" ")},
-    )
-
 # Add comment to the old PR
-post_request(
-    f"https://api.github.com/repos/{REPOSITORY}/issues/{PR_NUMBER}/comments",
-    headers={"Authorization": f"token {GITHUB_TOKEN}"},
-    json={"body": f"This Pull Request is now being tested in {PR_URL}"},
-)
+api.issues.create_comment(REPOSITORY.split("/")[0], REPOSITORY.split("/")[-1], PR_NUMBER, body=f"This Pull Request is now being tested on the following branch: https://github.com/binderhub-test-org/pr-test/tree/test-this-pr/{PR_NUMBER}")

--- a/src/main.py
+++ b/src/main.py
@@ -9,10 +9,14 @@ REPOSITORY = (
     os.environ["INPUT_REPOSITORY"] if "INPUT_REPOSITORY" in os.environ else None
 )
 GITHUB_ISSUE_CONTEXT = (
-    json.loads(os.environ["INPUT_GITHUB-ISSUE-CONTEXT"]) if "INPUT_GITHUB-ISSUE-CONTEXT" in os.environ else None
+    json.loads(os.environ["INPUT_GITHUB-ISSUE-CONTEXT"])
+    if "INPUT_GITHUB-ISSUE-CONTEXT" in os.environ
+    else None
 )
 GITHUB_TOKEN = (
-    github_token() if "INPUT_GITHUB-TOKEN" not in os.environ else os.environ["INPUT_GITHUB-TOKEN"]
+    github_token()
+    if "INPUT_GITHUB-TOKEN" not in os.environ
+    else os.environ["INPUT_GITHUB-TOKEN"]
 )
 
 # Check required environment variables are set
@@ -106,4 +110,9 @@ _ = run_cmd(
 )
 
 # Add comment to the old PR
-api.issues.create_comment(REPOSITORY.split("/")[0], REPOSITORY.split("/")[-1], PR_NUMBER, body=f"This Pull Request is now being tested on the following branch: https://github.com/binderhub-test-org/pr-test/tree/test-this-pr/{PR_NUMBER}")
+api.issues.create_comment(
+    REPOSITORY.split("/")[0],
+    REPOSITORY.split("/")[-1],
+    PR_NUMBER,
+    body=f"This Pull Request is now being tested on the following branch: https://github.com/binderhub-test-org/pr-test/tree/test-this-pr/{PR_NUMBER}",
+)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,30 +1,7 @@
 """
 Helper functions
 """
-import requests
 import subprocess
-
-
-def post_request(
-    url: str, headers: dict = None, json: dict = None, return_json: bool = True
-) -> None:
-    """Send a POST request to an HTTP API endpoint
-    Args:
-        url (str): The URL to send the request to
-        headers (dict, optional): A dictionary of any headers to send with the
-            request. Defaults to None.
-        json (dict, optional): A dictionary containing JSON payload to send with
-            the request. Defaults to None.
-        return_json (bool, optional): Return the JSON payload response.
-            Defaults to False.
-    """
-    resp = requests.post(url, headers=headers, json=json)
-
-    if not resp:
-        raise RuntimeError(resp.text)
-
-    if return_json:
-        return resp.json()
 
 
 def run_cmd(cmd: list) -> dict:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import pytest
-import responses
-from src.utils import post_request, run_cmd
+from src.utils import run_cmd
 
 
 def test_run_cmd():
@@ -17,38 +16,3 @@ def test_run_cmd_exception():
 
     with pytest.raises(FileNotFoundError):
         run_cmd(test_cmd)
-
-
-@responses.activate
-def test_post_request():
-    test_url = "http://jsonplaceholder.typicode.com/"
-    test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}
-    json = {"Payload": "Send this with the request"}
-
-    responses.add(responses.POST, test_url, json={"Request": "Sent"}, status=200)
-
-    post_request(test_url, headers=test_header, json=json)
-
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == test_url
-    assert responses.calls[0].response.text == '{"Request": "Sent"}'
-
-
-@responses.activate
-def test_post_request_exception():
-    test_url = "http://josnplaceholder.typicode.com/"
-    test_header = {"Authorization": "token ThIs_Is_A_ToKeN"}
-    json = {"Payload": "Send this with the request"}
-
-    responses.add(
-        responses.POST,
-        test_url,
-        body="Could not reach provided URL",
-        status=500,
-    )
-
-    with pytest.raises(RuntimeError):
-        post_request(test_url, headers=test_header, json=json)
-
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == test_url


### PR DESCRIPTION
- Use GhApi instead of requests to interact with GitHub
- No longer open a new Pull Request, just push to a new branch
- Reduce number of input variables, make them all optional and set defaults