### PR TITLE
update author_association example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ jobs:
       # Check the comment contains the trigger string
       contains(github.event.comment.body, '/test-this-pr') &&
       # Check the comment author has appropriate permissions
-      (
-        (github.event.issue.author_association == 'OWNER') ||
-        (github.event.issue.author_association == 'COLLABORATOR') ||
-        (github.event.issue.author_association == 'CONTRIBUTOR') ||
-        (github.event.issue.author_association == 'MEMBER')
+      contains(
+        ['OWNER', 'COLLABORATOR', 'CONTRIBUTOR', 'MEMBER'],
+        github.event.comment.author_association
       )
 
     steps:


### PR DESCRIPTION
- comment author's association is `event.comment.author_association` (`issue.author_association` is the PR owner, so anyone could make a comment to test a PR if the PR author should have permission)
- use [contains](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#contains) function to simplify check against multiple values
