### PR TITLE
Refactor action input variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ However if you have tests that require secrets, such as deploying to staging env
 
 This repository is a Docker-based GitHub Action that will push the changes of a pull request opened from a fork into a new branch in the parent repo so test workflows that require secrets can be executed.
 
+You will need to create a GitHub access token with enough permissions to write to the parent repo and save this as a repository secret.
+If the parent repo is public, `public_repo` should be enough.
+
 ## Inputs
 
 | Input variable | Description | Required? | Default value |
 | :--- | :--- | :--- | :--- |
+| `access-token` | A GitHub token with read/write access to the parent repository | Yes |  |
 | `repository` | The name of the parent repository in the form `owner/project` | No | `${{ github.repository }}` |
 | `pr-number` | The number of the Pull Request to be tested | No | `${{ github.event.issue.number }}` |
-| `github-token` | A GitHub token with read/write access to the parent repository | No | `${{ github.token }}` |
-| `author-name` | The name of the user that will be displayed as the author of the commit | No | `CI User` |
-| `author-email` | The email of the user that will be displayed as the author of the commit | No | `ci-user@github.local` |
 
 ## Example Usage
 
@@ -44,4 +45,6 @@ jobs:
 
     steps:
       - uses: sgibson91/test-this-pr-action@main
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ description: |
   Copy a PR from a forked repo into a branch on the parent repo so that
   workflows that require secrets can be run
 inputs:
+  access-token:
+    description: |
+      A GitHub access token with enough permissions to write to the parent repo
+    required: true
   repository:
     description: "The repository id in the form 'owner/project'"
     required: false
@@ -12,27 +16,10 @@ inputs:
     description: "The number of the Pull Request to be tested"
     required: false
     default: ${{ github.event.issue.number }}
-  github-token:
-    description: |
-      A GitHub token with enough permissions to write to the parent repo
-    required: false
-    default: ${{ github.token }}
-  author-name:
-    description: |
-      The name of the user that will be displayed as the author of the commit
-    required: false
-    default: "CI User"
-  author-email:
-    description: |
-      The email of the user that will be displayed as the author of the commit
-    required: false
-    default: "ci-user@github.local"
 runs:
   using: "docker"
   image: "Dockerfile"
   args:
+    - ${{ inputs.access-token }}
     - ${{ inputs.repository }}
     - ${{ inputs.pr-number }}
-    - ${{ inputs.github-token }}
-    - ${{ inputs.author-name }}
-    - ${{ inputs.author-email }}

--- a/src/main.py
+++ b/src/main.py
@@ -4,29 +4,21 @@ from ghapi.all import GhApi
 from ghapi.actions import github_token
 
 # Set required environment variables
+ACCESS_TOKEN = (
+    github_token()
+    if "INPUT_ACCESS-TOKEN" not in os.environ
+    else os.environ["INPUT_ACCESS-TOKEN"]
+)
 REPOSITORY = (
     os.environ["INPUT_REPOSITORY"] if "INPUT_REPOSITORY" in os.environ else None
 )
 PR_NUMBER = os.environ["INPUT_PR-NUMBER"] if "INPUT_PR-NUMBER" in os.environ else None
-GITHUB_TOKEN = (
-    github_token()
-    if "INPUT_GITHUB-TOKEN" not in os.environ
-    else os.environ["INPUT_GITHUB-TOKEN"]
-)
-AUTHOR_NAME = (
-    os.environ["INPUT_AUTHOR-NAME"] if "INPUT_AUTHOR-NAME" in os.environ else None
-)
-AUTHOR_EMAIL = (
-    os.environ["INPUT_AUTHOR-EMAIL"] if "INPUT_AUTHOR-EMAIL" in os.environ else None
-)
 
 # Check required environment variables are set
 REQUIRED_ENV_VARS = {
+    "ACCESS_TOKEN": ACCESS_TOKEN,
     "REPOSITORY": REPOSITORY,
     "PR_NUMBER": PR_NUMBER,
-    "GITHUB_TOKEN": GITHUB_TOKEN,
-    "AUTHOR_NAME": AUTHOR_NAME,
-    "AUTHOR_EMAIL": AUTHOR_EMAIL,
 }
 
 for VARNAME, VAR in REQUIRED_ENV_VARS.items():
@@ -36,16 +28,12 @@ for VARNAME, VAR in REQUIRED_ENV_VARS.items():
 # Set repository name
 REPO_NAME = REPOSITORY.split("/")[-1]
 
-# Set git config
-_ = run_cmd(["git", "config", "--global", "user.name", AUTHOR_NAME])
-_ = run_cmd(["git", "config", "--global", "user.email", AUTHOR_EMAIL])
-
 # Clone the parent repo
 _ = run_cmd(
     [
         "git",
         "clone",
-        f"https://{GITHUB_TOKEN}:x-oauth-basic@github.com/{REPOSITORY}.git",
+        f"https://{ACCESS_TOKEN}:x-oauth-basic@github.com/{REPOSITORY}.git",
     ]
 )
 
@@ -69,7 +57,7 @@ _ = run_cmd(
 )
 
 # Initialise GhApi
-api = GhApi(token=GITHUB_TOKEN)
+api = GhApi(token=ACCESS_TOKEN)
 
 # Add comment to the old PR
 api.issues.create_comment(


### PR DESCRIPTION
- Remove AUTHOR_NAME and AUTHOR_EMAIL. Identity will be handled by GitHub
  PAT
- Rename GITHUB_TOKEN to ACCESS_TOKEN. So as not to be confused with
  default GITHUB_TOKEN, which I don't think has enough permissions
- Update action metadata
- Update documentation in README