### PR TITLE
Remove CONTRIBUTOR from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ If the parent repo is public, `public_repo` should be enough.
 
 The below example demonstrates how to trigger the GitHub Action by leaving a comment containing `/test-this-pr` on a pull request, providing the comment author has appropriate permissions on the parent repository.
 
+**NOTE: These permissions are provided as an _example only_ and users should carefully read the [GitHub documentation](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation) before deciding which roles to use.**
+
 ```yaml
 name: Move forked-PR into parent repo for testing
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
       contains(github.event.comment.body, '/test-this-pr') &&
       # Check the comment author has appropriate permissions
       contains(
-        ['OWNER', 'COLLABORATOR', 'CONTRIBUTOR', 'MEMBER'],
+        ['OWNER', 'COLLABORATOR', 'MEMBER'],
         github.event.comment.author_association
       )
 


### PR DESCRIPTION
### Summary
From https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
> CONTRIBUTOR
> Author has previously committed to the repository.

I don't think you'd want that as it means anyone who's authored a commit in the repo would have permission

### What's changed?
Updated `Check the comment author has appropriate permissions` section in README

### What should a reviewer concetrate their feedback on?
Review other roles on https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
For example, the README preamble to this section says
> ... providing the comment author has appropriate permissions on the parent repository.

but
> MEMBER
> Author is a member of the organization that owns the repository.

doesn't mean they have push access to the repo. Maybe it should be removed too, or a clarification added somewhere?