### PR TITLE
Tweaks to input variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ If the parent repo is public, `public_repo` should be enough.
 
 | Input variable | Description | Required? | Default value |
 | :--- | :--- | :--- | :--- |
-| `access-token` | A GitHub token with read/write access to the parent repository | Yes |  |
+| `access_token` | A GitHub token with read/write access to the parent repository | Yes |  |
 | `repository` | The name of the parent repository in the form `owner/project` | No | `${{ github.repository }}` |
-| `pr-number` | The number of the Pull Request to be tested | No | `${{ github.event.issue.number }}` |
+| `pr_number` | The number of the Pull Request to be tested | No | `${{ github.event.issue.number }}` |
 
 ## Example Usage
 
@@ -41,12 +41,12 @@ jobs:
       contains(github.event.comment.body, '/test-this-pr') &&
       # Check the comment author has appropriate permissions
       contains(
-        ['OWNER', 'COLLABORATOR', 'MEMBER'],
-        github.event.comment.author_association
+        github.event.comment.author_association,
+        ['OWNER', 'COLLABORATOR', 'MEMBER']
       )
 
     steps:
       - uses: sgibson91/test-this-pr-action@main
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.ACCESS_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: |
   Copy a PR from a forked repo into a branch on the parent repo so that
   workflows that require secrets can be run
 inputs:
-  access-token:
+  access_token:
     description: |
       A GitHub access token with enough permissions to write to the parent repo
     required: true
@@ -12,7 +12,7 @@ inputs:
     description: "The repository id in the form 'owner/project'"
     required: false
     default: ${{ github.repository }}
-  pr-number:
+  pr_number:
     description: "The number of the Pull Request to be tested"
     required: false
     default: ${{ github.event.issue.number }}
@@ -20,6 +20,6 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.access-token }}
+    - ${{ inputs.access_token }}
     - ${{ inputs.repository }}
-    - ${{ inputs.pr-number }}
+    - ${{ inputs.pr_number }}

--- a/src/main.py
+++ b/src/main.py
@@ -7,19 +7,19 @@ from ghapi.actions import github_token
 # Set required environment variables
 ACCESS_TOKEN = (
     github_token()
-    if "INPUT_ACCESS-TOKEN" not in os.environ
-    else os.environ["INPUT_ACCESS-TOKEN"]
+    if "INPUT_ACCESS_TOKEN" not in os.environ
+    else os.environ["INPUT_ACCESS_TOKEN"]
 )
 REPOSITORY = (
     os.environ["INPUT_REPOSITORY"] if "INPUT_REPOSITORY" in os.environ else None
 )
-PR_NUMBER = os.environ["INPUT_PR-NUMBER"] if "INPUT_PR-NUMBER" in os.environ else None
+PR_NUMBER = os.environ["INPUT_PR_NUMBER"] if "INPUT_PR_NUMBER" in os.environ else None
 
 # Check required environment variables are set
 REQUIRED_ENV_VARS = {
-    "ACCESS_TOKEN": ACCESS_TOKEN,
-    "REPOSITORY": REPOSITORY,
-    "PR_NUMBER": PR_NUMBER,
+    "INPUT_ACCESS_TOKEN": ACCESS_TOKEN,
+    "INPUT_REPOSITORY": REPOSITORY,
+    "INPUT_PR_NUMBER": PR_NUMBER,
 }
 
 logger.info("Checking environment variables...")


### PR DESCRIPTION
Make the variable names easier to use on the command line by consistently using underscores instead of a mix of underscores and hyphens.