### PR TITLE
Publish the Action on Docker Hub

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,20 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  docker-build-push:
+    uses: sgibson91/.github/.github/workflows/docker-build.yaml@main
+    with:
+      image_name: sgibson91/test-this-pr-action
+    secrets:
+      docker_username: ${{ secrets.DOCKER_USERNAME }}
+      docker_password: ${{ secrets.DOCKER_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: ${{ github.event.issue.number }}
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://sgibson91/test-this-pr-action"
   args:
     - ${{ inputs.access_token }}
     - ${{ inputs.repository }}


### PR DESCRIPTION
In an effort to speed up the runtime of test-this-pr in GitHub Actions, the Docker image will now be built and pushed to Docker Hub in CI, and the action metadata references the built image on Docker Hub. Hopefully thi will prevent the image from being built every time the action is run.